### PR TITLE
Update CI from clang-12 to clang-15

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         build-type: [Debug, RelWithDebInfo, Release]
-        compiler: [{c: gcc-10, cpp: g++-10}, {c: gcc-11, cpp: g++-11, code-cov: true}, {c: clang-12, cpp: clang++-12}, {c: clang-13, cpp: clang++-13}, {c: clang-14, cpp: clang++-14}]
+        compiler: [{c: gcc-10, cpp: g++-10}, {c: gcc-11, cpp: g++-11, code-cov: true}, {c: clang-13, cpp: clang++-13}, {c: clang-14, cpp: clang++-14}, {c: clang-15, cpp: clang++-15}]
           
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
removed: [clang-12](https://github.com/actions/runner-images/issues/8263)
new: [clang-15](https://github.com/actions/runner-images/issues/8253)